### PR TITLE
Update dotnet.yml - Specifying Clocking project folder

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore \ClockingApp
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build \ClockingApp --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test \ClockingApp --no-build --verbosity normal


### PR DESCRIPTION
As now the root directory (and solution) contains two projects, .net core one and docker, it's needed for the `dotnet` command to specify the path of the desired project to restore/build/test.